### PR TITLE
Dynamically find the factories file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'vimrunner'
-gem 'rspec'
+gem 'pry'
 gem 'rake'
+gem 'rspec'
+gem 'vimrunner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     diff-lcs (1.2.5)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -11,12 +17,14 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
+    slop (3.6.0)
     vimrunner (0.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   rake
   rspec
   vimrunner

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Rfactory [![Build Status](https://travis-ci.org/christoomey/vim-rfactory.svg?branch=master)](https://travis-ci.org/christoomey/vim-rfactory)
 ============================================================================================================================================
 
-Rfactory is a vim plugin for rapid navigation to [Factory Girl] factory
-definitions within Vim.
+`Rfactory` is a vim plugin for rapid navigation to [Factory Girl][] factory
+definitions within Vim, inspired by the navigation commands in [Rails.vim][].
 
 ![rfactory navigation demo][]
 
@@ -13,16 +13,37 @@ definitions within Vim.
 Usage
 -----
 
-While on a factory reference in a spec file, run `:Rfactory` to navigate to
-the factory definition. If the current line contains a FactoryGirl trait
-reference, you will be taken to that trait.
+With your cursor anywhere on a line containing a FactoryGirl reference, e.g.
+`create(:user)`, run `:Rfactory` to navigate to the `:user` factory
+definition. If the current line contains a [FactoryGirl trait][] reference,
+you will be taken to the line that defines the trait within the parent
+factory.
 
-Configuration
--------------
+There are variants to the `:Rfactory` command to open the factories file in
+your preferred split or tab configuration.
 
-`:Rfactory` will look for factories in `spec/factories.rb`. Overwrite
-`g:rfactory_factory_location` to change this location.
+[FactoryGirl trait]: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#traits
 
-```vim
-let g:rfactory_factory_location = "spec/support/factories.rb"
+Command      | Action
+-------------|-----------------
+`:Rfactory`  | `:edit` the file
+`:RSfactory` | `:split` the file
+`:RVfactory` | `:vsplit` the file
+`:RTfactory` | `:tabedit` the file
+`:REfactory` | (alias for `:Rfactory`)
+
+Requirements
+------------
+
+`Rfactory` expects the factory file or files to be in one of the standard
+factory file locations as specified in the [Defining Factories section][] of the
+FactoryGirl docs, specifically:
+
+``` txt
+test/factories.rb
+spec/factories.rb
+test/factories/*.rb
+spec/factories/*.rb
 ```
+
+[Defining Factories section]: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#defining-factories

--- a/plugin/rfactory.vim
+++ b/plugin/rfactory.vim
@@ -1,30 +1,96 @@
-if !exists("g:rfactory_factory_location")
-  let g:rfactory_factory_location = "spec/factories.rb"
-endif
-
 let rfactory_fg_methods = ['create', 'build', 'build_stubbed', 'attributes_for']
 let method_pattern = '\<\%('. join(rfactory_fg_methods, '\|') . '\)' " Non capturing 'or'
 let symbol_pattern = '\(:\w\+\)'
 let optional_trait_pattern = '\%(, '.symbol_pattern.'\)\?'
 let s:pattern = method_pattern . '.' . symbol_pattern . optional_trait_pattern
+let g:rfactory_debug = []
+let s:FALSE = 0
+let s:TRUE = 1
+let s:factory_path_patterns = [
+      \ "spec/factories.rb",
+      \ "test/factories.rb",
+      \ "spec/factories/*.rb",
+      \ "test/factories/*.rb"
+      \ ]
 
 function! s:FactoryOnCurrentLine()
-  return matchlist(getline('.'), s:pattern)
+  return matchlist(getline("."), s:pattern)
+endfunction
+
+function! s:Debug(msg)
+  call add(g:rfactory_debug, a:msg)
+endfunction
+
+function! s:FactoryFilePaths()
+  let results = []
+  for pattern in s:factory_path_patterns
+    let files_for_pattern = s:FilesForGlobAsList(pattern)
+    call extend(results, files_for_pattern)
+  endfor
+  return results
+endfunction
+
+function! s:FilesForGlobAsList(glob_pattern)
+  let use_wilgignore = s:FALSE
+  return split(glob(a:glob_pattern, use_wilgignore), "\n")
+endfunction
+
+function! s:BuildFactoryContext()
+  let factory_definition = s:FactoryOnCurrentLine()
+  let factory = { "is_present": len(factory_definition) }
+  if factory.is_present
+    let factory["name"] = factory_definition[1]
+    let factory["trait"] = factory_definition[2]
+  endif
+  return factory
+endfunction
+
+function! s:TryToFindTrait(trait)
+  if a:trait != ""
+    call search(".*trait." . a:trait)
+  endif
+endfunction
+
+function! s:CenterFactoryInWindow()
+  normal! zz
+endfunction
+
+function! s:FactoryDefinitionFound(factory_name)
+  return search(".*factory." . a:factory_name) != 0
+endfunction
+
+function! s:SearchAndFocusOnFactory(factory, factory_file)
+  execute "edit " . a:factory_file
+  if s:FactoryDefinitionFound(a:factory.name)
+    call s:TryToFindTrait(a:factory.trait)
+    call s:CenterFactoryInWindow()
+    let factory_found = s:TRUE
+  else
+    let factory_found = s:FALSE
+  endif
+  return factory_found
+endfunction
+
+function! s:SearchForFactoryInFiles(factory, factory_file_paths)
+  for factory_file in a:factory_file_paths
+    if s:SearchAndFocusOnFactory(a:factory, factory_file)
+      break
+    endif
+  endfor
+endfunction
+
+function! s:OpenFirstFactoryFile(factory_files)
+  execute "edit " . a:factory_files[0]
 endfunction
 
 function! s:Rfactory(edit_method)
-  let factory = s:FactoryOnCurrentLine()
-  if len(factory)
-    let factory_name = factory[1]
-    let factory_trait = factory[2]
-    execute a:edit_method . ' ' . g:rfactory_factory_location
-    call search('.*factory.' . factory_name)
-    if factory_trait !=? ''
-      call search('.*trait.' . factory_trait)
-    endif
-    normal! zz
+  let factory = s:BuildFactoryContext()
+  let factory_files = s:FactoryFilePaths()
+  execute a:edit_method
+  if factory.is_present
+    call s:SearchForFactoryInFiles(factory, factory_files)
   else
-    execute a:edit_method . ' ' . g:rfactory_factory_location
+    call s:OpenFirstFactoryFile(factory_files)
   endif
 endfunction
 


### PR DESCRIPTION
Rather than relying on a setting and possible override, this update will dynamically find the factories file under the spec/ directory. This is especially useful if moving between different projects which store the factories.rb file in different places.