### PR TITLE
Add support for "*_pair" and "*_list" methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Usage
 
 With your cursor anywhere on a line containing a FactoryGirl reference, e.g.
 `create(:user)`, run `:Rfactory` to navigate to the `:user` factory
-definition. If the current line contains a [FactoryGirl trait][] reference,
+definition.
+
+If the current line contains a [FactoryGirl trait][] reference,
 you will be taken to the line that defines the trait within the parent
 factory.
 
@@ -47,3 +49,18 @@ spec/factories/*.rb
 ```
 
 [Defining Factories section]: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#defining-factories
+
+Support
+-------
+
+The plugin does its best to support each of the FactoryGirl methods,
+specifically:
+
+- `create`
+- `build`
+- `build_stubbed`
+- `attributes_for`
+
+In addition, for each of the above methods, `Rfactory` also supports the
+`<method>_pair` and `<method>_list` variants (e.g. `create_pair` and
+`create_list`).

--- a/plugin/rfactory.vim
+++ b/plugin/rfactory.vim
@@ -1,8 +1,21 @@
-let rfactory_fg_methods = ['create', 'build', 'build_stubbed', 'attributes_for']
-let method_pattern = '\<\%('. join(rfactory_fg_methods, '\|') . '\)' " Non capturing 'or'
-let symbol_pattern = '\(:\w\+\)'
-let optional_trait_pattern = '\%(, '.symbol_pattern.'\)\?'
-let s:pattern = method_pattern . '.' . symbol_pattern . optional_trait_pattern
+let s:rfactory_fg_methods = ['create', 'build', 'build_stubbed', 'attributes_for']
+let s:word_boundary = '\<'
+let s:non_capturing_group = '\%('
+let s:symbol_pattern = '\(:\w\+\)'
+let s:list_count_pattern = ', \d\+'
+let s:factory_name_pattern = s:symbol_pattern
+let s:method_pattern = s:non_capturing_group .
+      \ join(s:rfactory_fg_methods, '\|') . '\)'
+let s:optional_pair_variant = s:non_capturing_group . '_pair\)\?'
+let s:optional_trait_pattern = s:non_capturing_group . ', ' .
+      \ s:symbol_pattern . '\)\?'
+
+let s:factory_method_pattern = s:word_boundary . s:method_pattern .
+      \ s:optional_pair_variant . '.' . s:factory_name_pattern .
+      \ s:optional_trait_pattern
+let s:factory_list_method_pattern = s:word_boundary . s:method_pattern . '_list' .
+      \ '.' . s:factory_name_pattern . s:list_count_pattern . s:optional_trait_pattern
+
 let g:rfactory_debug = []
 let s:FALSE = 0
 let s:TRUE = 1
@@ -14,7 +27,16 @@ let s:factory_path_patterns = [
       \ ]
 
 function! s:FactoryOnCurrentLine()
-  return matchlist(getline("."), s:pattern)
+  let list_match = s:MatchlistOnCurrentLine(s:factory_list_method_pattern)
+  if empty(list_match)
+    return s:MatchlistOnCurrentLine(s:factory_method_pattern)
+  else
+    return list_match
+  end
+endfunction
+
+function! s:MatchlistOnCurrentLine(pattern)
+  return matchlist(getline("."), a:pattern)
 endfunction
 
 function! s:Debug(msg)

--- a/spec/plugin/rfactory_spec.rb
+++ b/spec/plugin/rfactory_spec.rb
@@ -17,11 +17,41 @@ describe 'Rfactory' do
         expect(current_path).to eq 'spec/factories.rb'
         expect(current_line).to eq 'factory :user do'
       end
+
+      it "supports the '#{method}_pair' factory method" do
+        create_factories_file
+        edit_spec_file_with_text "users = #{method}_pair(:user)"
+
+        vim.command 'Rfactory'
+
+        expect(current_line).to eq 'factory :user do'
+        expect(current_path).to eq 'spec/factories.rb'
+      end
+
+      it "supports the '#{method}_list' factory method" do
+        create_factories_file
+        edit_spec_file_with_text "users = #{method}_list(:user, 3)"
+
+        vim.command 'Rfactory'
+
+        expect(current_line).to eq 'factory :user do'
+        expect(current_path).to eq 'spec/factories.rb'
+      end
     end
 
     it 'navigates to traits if present' do
       create_factories_file
       edit_spec_file_with_text 'user = create(:user, :with_token)'
+
+      vim.command 'Rfactory'
+
+      expect(current_path).to eq 'spec/factories.rb'
+      expect(current_line).to eq 'trait :with_token do'
+    end
+
+    it 'finds traits in _list FG method calls' do
+      create_factories_file
+      edit_spec_file_with_text 'users = create_list(:user, 3, :with_token)'
 
       vim.command 'Rfactory'
 


### PR DESCRIPTION
Each of the methods also has a _pair and a _list variant, e.g. `build_stubbed` -> `build_stubbed_pair`, `build_stubbed_list`. This PR adds support for them by extending the main factory pattern, and adding an additional pattern for the _list variant which takes an additional argument for the list count.

http://www.rubydoc.info/gems/factory_girl/file/GETTING_STARTED.md#Building_or_Creating_Multiple_Records