### PR TITLE
Remove unnecessary variable assignment

### DIFF
--- a/spec/plugin/rfactory_spec.rb
+++ b/spec/plugin/rfactory_spec.rb
@@ -176,7 +176,7 @@ describe 'Rfactory' do
   end
 
   def current_line
-    line = vim.command "echo getline('.')"
+    vim.command "echo getline('.')"
   end
 
   def current_path


### PR DESCRIPTION
This is more of a stylistic change. It also makes Syntastic shut up.