### PR TITLE
Rename FactoryGirl to FactoryBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 Rfactory [![Build Status](https://travis-ci.org/christoomey/vim-rfactory.svg?branch=master)](https://travis-ci.org/christoomey/vim-rfactory)
 ============================================================================================================================================
 
-`Rfactory` is a Vim plugin for rapid navigation to [Factory Girl][] factory
+`Rfactory` is a Vim plugin for rapid navigation to [FactoryBot][] factory
 definitions within Vim, inspired by the navigation commands in [Rails.vim][].
 
 ![rfactory navigation demo][]
 
-[Factory Girl]: https://github.com/thoughtbot/factory_girl
+[FactoryBot]: https://github.com/thoughtbot/factory_bot
 [Rails.vim]: https://github.com/tpope/vim-rails
 [rfactory navigation demo]: ./images/rfactory-navigation-demo.gif
 
 Usage
 -----
 
-With your cursor anywhere on a line containing a FactoryGirl reference, e.g.
+With your cursor anywhere on a line containing a FactoryBot reference, e.g.
 `create(:user)`, run `:Rfactory` to navigate to the `:user` factory
 definition.
 
-If the current line contains a [FactoryGirl trait][] reference,
+If the current line contains a [FactoryBot trait][] reference,
 you will be taken to the line that defines the trait within the parent
 factory.
 
 There are variants to the `:Rfactory` command to open the factories file in
 your preferred split or tab configuration.
 
-[FactoryGirl trait]: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#traits
+[FactoryBot trait]: https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#traits
 
 Command      | Action
 -------------|-----------------
@@ -39,7 +39,7 @@ Requirements
 
 `Rfactory` expects the factory file or files to be in one of the standard
 factory file locations as specified in the [Defining Factories section][] of the
-FactoryGirl docs, specifically:
+FactoryBot docs, specifically:
 
 ``` txt
 test/factories.rb
@@ -48,12 +48,12 @@ test/factories/*.rb
 spec/factories/*.rb
 ```
 
-[Defining Factories section]: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#defining-factories
+[Defining Factories section]: https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#defining-factories
 
 Support
 -------
 
-The plugin does its best to support each of the FactoryGirl methods,
+The plugin does its best to support each of the FactoryBot methods,
 specifically:
 
 - `create`

--- a/spec/plugin/rfactory_spec.rb
+++ b/spec/plugin/rfactory_spec.rb
@@ -8,7 +8,7 @@ describe 'Rfactory' do
 
   context ':Rfactory' do
     %w{create build build_stubbed attributes_for}.each do |method|
-      it "maps FG method '#{method}' to its factory" do
+      it "maps FactoryBot method '#{method}' to its factory" do
         create_factories_file
         edit_spec_file_with_text "user = #{method}(:user)"
 
@@ -49,7 +49,7 @@ describe 'Rfactory' do
       expect(current_line).to eq 'trait :with_token do'
     end
 
-    it 'finds traits in _list FG method calls' do
+    it 'finds traits in _list FactoryBot method calls' do
       create_factories_file
       edit_spec_file_with_text 'users = create_list(:user, 3, :with_token)'
 
@@ -204,7 +204,7 @@ describe 'Rfactory' do
   def create_factories_file(path: "spec/factories.rb", factories_text: nil)
     FileUtils.mkdir_p File.dirname(path)
     factories_text ||= normalize_string_indent <<-EOS
-      FactoryGirl.define do
+      FactoryBot.define do
         factory :user do
           name 'Bob smith'
 


### PR DESCRIPTION
The FactoryGirl gem has been renamed to FactoryBot. Refer to the gem by
its new name, and remove references to the old name.

There's one more mention of "FactoryGirl" in the repo description:

<img width="1005" alt="last_reference_to_factory_girl" src="https://user-images.githubusercontent.com/16706305/42725835-92711310-8758-11e8-87cb-c1fd9306b276.png">
